### PR TITLE
* Updated pt schema for v1, backwards compatible with v0.19

### DIFF
--- a/Kokoro/models.py
+++ b/Kokoro/models.py
@@ -579,7 +579,10 @@ def build_model(path, device):
         decoder=decoder.to(device).eval(),
         text_encoder=text_encoder.to(device).eval(),
     )
-    for key, state_dict in torch.load(path, map_location='cpu', weights_only=True)['net'].items():
+    checkpoint = torch.load(path, map_location='cpu', weights_only=True)
+    if 'net' in checkpoint:  # For backwards compatability with v0_19
+        checkpoint = checkpoint['net']
+    for key, state_dict in checkpoint.items():
         assert key in model, key
         try:
             model[key].load_state_dict(state_dict)


### PR DESCRIPTION
Kokoro v1 and v0.19 load correctly, Fixes #6 

I also noticed some voices (like af_heart) are limited to 509 tokens, it might be worth lowering the default `chunk_size` to 500.